### PR TITLE
move sidebar collapse\expand logic to back-end to avoid animation

### DIFF
--- a/RaccoonBlog.Web/Content/js/setup.js
+++ b/RaccoonBlog.Web/Content/js/setup.js
@@ -35,14 +35,13 @@
 
         enableCommentsPreview();
         adjustSize();
-        showSidebarOnFirstVisits();
         setPreferredView();
         makeTablesResponsive();
     }
 
     function initEvents() {
         openbtn.click(toggleMenu);
-        enlargebtn.click(toggleSidebar);
+        enlargebtn.click(toggleSidebarOnClick);
         showgrid.click(toggleGrid);
         showstack.click(toggleStack);
         openTags.click(toggleTags);
@@ -93,6 +92,11 @@
         if (showCondition) {
             $('.container').toggleClass('hideSidebar');
         }
+    }
+
+    function toggleSidebarOnClick() {
+        toggleSidebar();
+        setSidebarHiddenInCookies();
     }
 
     function toggleMenu() {
@@ -185,6 +189,15 @@
         cookies.create('visitCount', value);
     }
 
+    function setSidebarHiddenInCookies() {
+        cookies.create('hideSidebar', true);
+    }
+
+    function getSidebarHiddenFromCookies() {
+        let cookieVal = cookies.read('hideSidebar');
+        return cookieVal === 'true';
+    }
+
     function isNewSession() {
         const data = sessionStorage.getItem('initializedSession');
         return !data || data !== 'true';
@@ -193,23 +206,6 @@
     function initSession() {
         sessionStorage.setItem('initializedSession', 'true');
         bumpVisitCount();
-    }
-
-    function shouldShowSidebar() {
-        const isOnMainPage = window.location.pathname === '/';
-        if (isOnMainPage) {
-            return true;
-        }
-
-        const visitCountMax = 10;
-        const visitCount = getVisitCount();
-        return visitCount < visitCountMax;
-    }
-
-    function showSidebarOnFirstVisits() {
-        if (shouldShowSidebar()) {
-            toggleSidebar();
-        }
     }
 
     function setPreferredView() {

--- a/RaccoonBlog.Web/Helpers/CookieJar.cs
+++ b/RaccoonBlog.Web/Helpers/CookieJar.cs
@@ -1,0 +1,43 @@
+﻿using System.Web;
+
+namespace RaccoonBlog.Web.Helpers
+{
+    public static class CookieJar
+    {
+        private static HttpRequest CurrentRequest => HttpContext.Current.Request;
+        private static HttpCookieCollection RequestCookies => CurrentRequest.Cookies;
+
+        private static string GetRequestCookieText(string name)
+        {
+            var cookie = RequestCookies[name];
+            return cookie?.Value;
+        }
+
+        private static bool? GetRequestCookieBool(string name)
+        {
+            var value = GetRequestCookieText(name);
+            if (string.IsNullOrEmpty(value))
+                return null;
+
+            return bool.Parse(value);
+        }
+
+        private static int? GetRequestCookieInt(string name)
+        {
+            var value = GetRequestCookieText(name);
+            if (string.IsNullOrEmpty(value))
+                return null;
+
+            return int.Parse(value);
+        }
+
+        public static bool? HideSidebar => GetRequestCookieBool(CookieNames.HideSidebar);
+        public static int? VisitCount => GetRequestCookieInt(CookieNames.VisitCount);
+
+        private static class CookieNames
+        {
+            public const string HideSidebar = "hideSidebar";
+            public const string VisitCount = "visitCount";
+        }
+    }
+}

--- a/RaccoonBlog.Web/Helpers/SidebarHelper.cs
+++ b/RaccoonBlog.Web/Helpers/SidebarHelper.cs
@@ -1,0 +1,25 @@
+﻿using System.Web;
+
+namespace RaccoonBlog.Web.Helpers
+{
+    public class SidebarHelper
+    {
+        private const int VisitCountMax = 10;
+
+        private static HttpRequest CurrentRequest => HttpContext.Current.Request;
+
+        public static bool ShouldShowSidebar()
+        {
+            var hasExplicitlyHidden = CookieJar.HideSidebar;
+            if (hasExplicitlyHidden == true)
+                return false;
+
+            var isOnMainPage = CurrentRequest.Path == "/";
+            if (isOnMainPage)
+                return true;
+
+            var visitCount = CookieJar.VisitCount.GetValueOrDefault();
+            return visitCount < VisitCountMax;
+        }
+    }
+}

--- a/RaccoonBlog.Web/RaccoonBlog.Web.csproj
+++ b/RaccoonBlog.Web/RaccoonBlog.Web.csproj
@@ -280,6 +280,7 @@
     <Compile Include="Extensions\XmlResult.cs" />
     <Compile Include="Helpers\Attributes\CustomHandleErrorAttribute.cs" />
     <Compile Include="Helpers\ConfigurationHelper.cs" />
+    <Compile Include="Helpers\CookieJar.cs" />
     <Compile Include="Helpers\CryptographyUtil.cs" />
     <Compile Include="Helpers\FutureRssAccessToken.cs" />
     <Compile Include="Helpers\PostHelper.cs" />
@@ -287,6 +288,7 @@
     <Compile Include="Helpers\Recaptcha2Helper.cs" />
     <Compile Include="Helpers\Recaptcha2Verifier.cs" />
     <Compile Include="Helpers\RedditHelper.cs" />
+    <Compile Include="Helpers\SidebarHelper.cs" />
     <Compile Include="Helpers\SignInHelper.cs" />
     <Compile Include="Helpers\ThemeLessTransform.cs" />
     <Compile Include="Helpers\RouteCollectionExtension.cs" />

--- a/RaccoonBlog.Web/Views/Shared/_Layout.cshtml
+++ b/RaccoonBlog.Web/Views/Shared/_Layout.cshtml
@@ -25,7 +25,14 @@
     @RenderSection("Style", false)
 </head>
 <body class="show-grid">
-    <div class="container hideSidebar">
+    @{
+        var containerClass = "container";
+        if (SidebarHelper.ShouldShowSidebar() == false)
+        {
+            containerClass += " hideSidebar";
+        }
+    }
+    <div class="@containerClass">
             <div class="leftSide">
                 <a href="@Url.Action("Index", "Posts")" class="logo">
                     <h1>@ViewBag.BlogConfig.Title</h1>


### PR DESCRIPTION
We render the initial HTML with the sidebar already collapsed
or expanded. This way we avoid sidebar animation after page load.