### PR TITLE
Changing Hibernating Rhinos to RavenDB

### DIFF
--- a/RaccoonBlog.Web/Controllers/SocialController.cs
+++ b/RaccoonBlog.Web/Controllers/SocialController.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
-//  <copyright file="SocialController.cs" company="Hibernating Rhinos LTD">
-//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  <copyright file="SocialController.cs" company="RavenDB LTD">
+//      Copyright (c) RavenDB LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
 

--- a/RaccoonBlog.Web/Models/Post.cs
+++ b/RaccoonBlog.Web/Models/Post.cs
@@ -1,6 +1,6 @@
 // //-----------------------------------------------------------------------
-// // <copyright company="Hibernating Rhinos LTD">
-// //     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+// // <copyright company="RavenDB LTD">
+// //     Copyright (c) RavenDB LTD. All rights reserved.
 // // </copyright>
 // //-----------------------------------------------------------------------
 using System;

--- a/RaccoonBlog.Web/Properties/AssemblyInfo.cs
+++ b/RaccoonBlog.Web/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("RaccoonBlog.Web")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Hibernating Rhinos")]
+[assembly: AssemblyCompany("RavenDB")]
 [assembly: AssemblyProduct("RaccoonBlog.Web")]
-[assembly: AssemblyCopyright("Copyright © Hibernating Rhinos 2011 - 2013")]
+[assembly: AssemblyCopyright("Copyright © RavenDB 2011 - 2025")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/RaccoonBlog.Web/Views/Legal/PrivacyPolicy.cshtml
+++ b/RaccoonBlog.Web/Views/Legal/PrivacyPolicy.cshtml
@@ -2,7 +2,7 @@
     <h1 class="text-center margin-top">Privacy Policy</h1>
     <div>
         <p>
-            We at Hibernating Rhinos Limited ("<strong>Hibernating Rhinos</strong>" "<strong>us</strong>", "<strong>we</strong>", or "<strong>our</strong>")
+            We at RavenDB Limited ("<strong>RavenDB</strong>" "<strong>us</strong>", "<strong>we</strong>", or "<strong>our</strong>")
             recognize and respect the importance of maintaining the privacy of our customers.
             This Privacy Notice describes the types of information we collect from you when you visit our websites ("<strong>Site</strong>"),
             download our applications ("<strong>App</strong>") and/or use our services ("<strong>Services</strong>").
@@ -11,8 +11,8 @@
             <a href="https://ayende.com/terms">https://ayende.com/terms</a> ("<strong>Terms</strong>").
         </p>
         <p>
-            Hibernating Rhinos Limited is the data controller in respect of some of the processing activities outlined in this Privacy Notice.
-            Our registration number is 513553742. Hibernating Rhinos Limited is the data processor with respect to the data that is processed by our customers using our App.
+            RavenDB Limited is the data controller in respect of some of the processing activities outlined in this Privacy Notice.
+            Our registration number is 513553742. RavenDB Limited is the data processor with respect to the data that is processed by our customers using our App.
             Our co-controllers are listed below.
         </p>
         <p>

--- a/RaccoonBlog.Web/Views/Legal/Terms.cshtml
+++ b/RaccoonBlog.Web/Views/Legal/Terms.cshtml
@@ -2,11 +2,11 @@
     <h1 class="text-center margin-top">Terms</h1>
     <div>
         <p class="lead">
-            By using the Hibernating Rhinos Ltd websites you are deemed to have read and agreed
+            By using the RavenDB Ltd websites you are deemed to have read and agreed
             to the terms and conditions:
         </p>
         <p>
-            Welcome to the Hibernating Rhinos Ltd sites (the "Site"). Through the Site, you will have access to
+            Welcome to the RavenDB Ltd sites (the "Site"). Through the Site, you will have access to
             resources and content which includes: (a) software and software service offerings ("software"); (b)
             Web pages, data, messages, text, images, photographs, graphics, audio and video such as podcasts
             and documents such as press releases, articles, newsletters ("Materials"); and (c) forums, discussion
@@ -18,11 +18,11 @@
         <p>
             The following terminology applies to these Terms and Conditions, Privacy Statement and <span style="font-weight:bold">Disclaimer</span>
             Notice and any or all Agreements: "Customer", “You” and “Your” refers to you, the person accessing
-            this website and accepting Hibernating Rhino's Ltd terms and conditions. "The Company", “Ourselves”,
+            this website and accepting RavenDB Ltd terms and conditions. "The Company", “Ourselves”,
             “We” and "Us", refers to our Company are terms of a legal agreement between you ("You" or "Your")
-            and Hibernating Rhinos Ltd. By accessing or using our Site or Content provided on or through the Sites,
+            and RavenDB Ltd. By accessing or using our Site or Content provided on or through the Sites,
             you agree to follow and be bound by the following terms and conditions concerning your access to and
-            use of the Site and the Content provided ("Terms of Use") and our Privacy Policy. Hibernating Rhinos
+            use of the Site and the Content provided ("Terms of Use") and our Privacy Policy. RavenDB
             reserves the right to revise the Terms of Use and Privacy Policy at any time without notice and effective
             when posted.
         </p>
@@ -46,11 +46,11 @@
         <h3>Disclaimer of Warranty</h3>
         <p>
             The site, and all the content provided on or through the site, are provided on an "As Is" and "As
-            Available" basis. Under no circumstances, shall Hibernating Rhinos Ltd, or affiliates be liable for any direct,
+            Available" basis. Under no circumstances, shall RavenDB Ltd, or affiliates be liable for any direct,
             indirect, incidental, special or consequential damages that result from the use of, its websites or material. The
             website may contain technical inaccuracies or typographical errors. The content of any documents on
             this website are believed to be current and accurate as of their publication dates.
-            Hibernating Rhinos Ltd. makes not warranty that:
+            RavenDB Ltd. makes not warranty that:
         </p>
         <ol>
             <li value="1">The site or content will meet your requirements.</li>
@@ -59,7 +59,7 @@
             <li>The quality of any content purchased or obtained through the site will meet your expectations.</li>
             <li>The content accessed, downloaded or obtained through the site is used at your own discretion and risk.</li>
             <li>
-                Hibernating Rhinos does not incur responsibility for any damages to the mentioned list below as a result from download or use of content:
+                RavenDB does not incur responsibility for any damages to the mentioned list below as a result from download or use of content:
                 <ul>
                     <li>Loss or damage to data.</li>
                     <li>
@@ -72,7 +72,7 @@
             </li>
         </ol>
         <p>
-            Hibernating Rhinos reserves the right to make changes or update to and monitor the use of the site and content
+            RavenDB reserves the right to make changes or update to and monitor the use of the site and content
             provided on or through the site at any time without notice.
         </p>
         <hr />

--- a/RaccoonBlog.Web/Views/Posts/List.cshtml
+++ b/RaccoonBlog.Web/Views/Posts/List.cshtml
@@ -9,7 +9,7 @@
     @{
         var title = ViewBag.BlogConfig.Title;
         var url = Request.Url.AbsoluteUri;
-        var description = "OREN EINI aka Ayende Rahien CEO of HIBERNATING RHINOS LTD, which develops RAVENDB, a NoSQL Open Source Document Database.";
+        var description = "OREN EINI aka Ayende Rahien CEO of RAVENDB LTD, which develops RAVENDB, a NoSQL Open Source Document Database.";
     }
 
     <meta name="og:site_name" content="@title">

--- a/RaccoonBlog.Web/Views/Welcome/Index.cshtml
+++ b/RaccoonBlog.Web/Views/Welcome/Index.cshtml
@@ -15,7 +15,7 @@
 	<h2>Welcome to RaccoonBlog!</h2>
 	<p>
 		RaccoonBlog is an official sample application for <a href="http://ravendb.net">RavenDB</a>, and as such it demonstrates best practices for using RavenDB.
-		RaccoonBlog is production ready, and is already driving real-world blogs like <a href="http://ayende.com">Ayende.com</a> and the <a href="http://blogs.hibernatingrhinos.com">Hibernating Rhinos blog</a>.
+		RaccoonBlog is production ready, and is already driving real-world blogs like <a href="http://ayende.com">Ayende.com</a> and the <a href="http://blogs.hibernatingrhinos.com">RavenDB blog</a>.
 	</p>
 	<p>Going through the sources, you can learn how to use RavenDB, and about various features it offers.</p>
 	<p>Starting your own blog using this software is easy, just review the blog configuration below, submit it when you are done, and your blog will be ready.</p>


### PR DESCRIPTION
This PR changes `Hibernating Rhinos` to `RavenDB`. The only place where it's left is the `licence.txt` that I'm not sure can be changed.