### PR TITLE
Fix vulnerable dependencies: pin Asn1/X509, remove unused RavenDB.Embedded from Web

### DIFF
--- a/RaccoonBlog.Web/RaccoonBlog.Web.csproj
+++ b/RaccoonBlog.Web/RaccoonBlog.Web.csproj
@@ -101,15 +101,14 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="RedditSharp" Version="2.0.0" />
     
-    <!-- RavenDB packages - ALL v6.0.104 for compatibility -->
     <PackageReference Include="RavenDB.Client" Version="7.2.1" />
-    <PackageReference Include="RavenDB.Embedded" Version="6.0.104" />
-    <PackageReference Include="RavenDB.TestDriver" Version="6.0.104" />
     <PackageReference Include="WilderMinds.MetaWeblog" Version="5.1.3" />
 
     <!-- Pin transitive dependencies to fix known vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
   </ItemGroup>
 
   <!-- Clean generated CSS files on Clean -->


### PR DESCRIPTION
## Summary

- **CVE-2017-11770**: pin `System.Security.Cryptography.X509Certificates` to `4.3.2` (was pulling `4.3.0` transitively)
- **CVE-2024-38095**: pin `System.Formats.Asn1` to `8.0.1` (inbox package, not in NuGet graph but flagged by scanners)
- **CVE-2018-8292**: remove `RavenDB.Embedded 6.0.104` and `RavenDB.TestDriver 6.0.104` from `RaccoonBlog.Web` — neither was used in production code, and the embedded server binary bundled by `RavenDB.Embedded` was shipping `System.Net.Http 4.1.0` into the container image (flagged by AWS Inspector)

`RavenDB.Embedded` and `RavenDB.TestDriver` remain in `RaccoonBlog.IntegrationTests` at `7.2.1`.

## Test plan

- [ ] `dotnet build RaccoonBlog.sln -c Release` passes (0 errors)
- [ ] `dotnet list package --vulnerable --include-transitive` reports no vulnerable packages for both projects