### PR TITLE
HRINTO-4810 - remove main.js reference from admin login page

### DIFF
--- a/RaccoonBlog.Web/Areas/Admin/Views/Login/Index.cshtml
+++ b/RaccoonBlog.Web/Areas/Admin/Views/Login/Index.cshtml
@@ -48,8 +48,7 @@
     <footer>
         <span class="small">Copyright © Raccoon Blog 2011 - 2015</span>
     </footer>
-    
-    <script src="~/Content/js/admin/main.js"></script>
+
     <script src="~/admin/js/bootstrap.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Issue:

https://issues.hibernatingrhinos.com/issue/HRINT-4810/ayende.com-remove-dead-admin-main.js-reference-from-login-page