### PR TITLE
HRINT-4835-1 - missing /blog prefix

### DIFF
--- a/RaccoonBlog.IntegrationTests/ImageUrlRewriterTests.cs
+++ b/RaccoonBlog.IntegrationTests/ImageUrlRewriterTests.cs
@@ -1,0 +1,37 @@
+using RaccoonBlog.Web.Infrastructure.AutoMapper.Profiles.Resolvers;
+using Xunit;
+
+namespace RaccoonBlog.IntegrationTests
+{
+    public class ImageUrlRewriterTests
+    {
+        private static string Rewrite(string html) => ImageUrlRewriter.RewriteImageUrls(html);
+
+        [Fact]
+        public void WhenImageHasAbsolutePath_UrlIsRewritten()
+        {
+            var result = Rewrite("<img src=\"/Images/foo.png\" />");
+
+            Assert.Contains("/blog/Images/foo.png", result);
+        }
+
+        [Fact]
+        public void WhenImageHasExternalUrl_UrlIsNotChanged()
+        {
+            var result = Rewrite("<img src=\"http://lostechies.com/gabrielschenker/files/2011/08/image_thumb.png\" />");
+
+            Assert.Contains("http://lostechies.com/gabrielschenker/files/2011/08/image_thumb.png", result);
+        }
+
+        [Fact]
+        public void WhenPostHasMultipleImages_AllUrlsAreRewritten()
+        {
+            var result = Rewrite(
+                "<img src=\"http://ayende.com/Blog/images/ayende_com/Blog/WindowsLiveWriter/BroadSupportindeed_A6E/image_thumb.png\" />" +
+                "<img src=\"Images/screenshot.png\" />");
+
+            Assert.Contains("/blog/Images/ayende_com/Blog/WindowsLiveWriter/BroadSupportindeed_A6E/image_thumb.png", result);
+            Assert.Contains("/blog/Images/screenshot.png", result);
+        }
+    }
+}

--- a/RaccoonBlog.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/RaccoonBlog.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -1,8 +1,11 @@
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using RaccoonBlog.Web.Infrastructure.DataProtection;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Session;
 using Raven.Embedded;
 using System;
@@ -46,6 +49,8 @@ namespace RaccoonBlog.IntegrationTests.Infrastructure
                 // Create a new test DocumentStore with a unique database name
                 _testDocumentStore = EmbeddedServerHelper.Instance.GetDocumentStore($"TestDb_{Guid.NewGuid()}");
                 
+                IndexCreation.CreateIndexes(typeof(Program).Assembly, _testDocumentStore);
+                
                 // Configure test store to wait for non-stale results
                 _testDocumentStore.OnBeforeQuery += (sender, args) =>
                 {
@@ -54,6 +59,11 @@ namespace RaccoonBlog.IntegrationTests.Infrastructure
 
                 // Register the test DocumentStore
                 services.AddSingleton(_testDocumentStore);
+                
+                services.Configure<KeyManagementOptions>(options =>
+                {
+                    options.XmlRepository = new RavenDbXmlRepository(_testDocumentStore);
+                });
 
                 // Register scoped IDocumentSession
                 services.AddScoped<IDocumentSession>(provider =>

--- a/RaccoonBlog.IntegrationTests/Web/Controllers/PostDetailsImageUrlTests.cs
+++ b/RaccoonBlog.IntegrationTests/Web/Controllers/PostDetailsImageUrlTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using RaccoonBlog.IntegrationTests.Infrastructure;
+using RaccoonBlog.Web.Models;
+using Raven.Client.Documents.Session;
+using Xunit;
+
+namespace RaccoonBlog.IntegrationTests.Web.Controllers
+{
+    public class PostDetailsImageUrlTests : RaccoonControllerTests
+    {
+        public PostDetailsImageUrlTests(TestWebApplicationFactory factory) : base(factory)
+        {
+            _ = factory.Services;
+        }
+
+        [Fact]
+        public async Task WhenPostHasWrongImage_ImageIsNowCorrect()
+        {
+            SeedPost("posts/1", "<img src=\"http://ayende.com/Blog/images/ayende_com/Blog/WindowsLiveWriter/BroadSupportindeed_A6E/image_thumb.png\" />");
+
+            Assert.Contains("http://ayende.com/Blog/images/", GetStoredBody("posts/1"));
+
+            var html = await RenderPost("posts/1");
+            
+            Assert.Contains("/blog/Images/ayende_com/Blog/WindowsLiveWriter/BroadSupportindeed_A6E/image_thumb.png", html);
+            Assert.DoesNotContain("http://ayende.com/Blog/images/", html);
+        }
+
+        [Fact]
+        public async Task WhenPostHasMissingImage_ImageIsNowPresent()
+        {
+            SeedPost("posts/2", "<img src=\"Images/screenshot.png\" />");
+
+            Assert.DoesNotContain("/blog/", GetStoredBody("posts/2"));
+
+            var html = await RenderPost("posts/2");
+            
+            Assert.Contains("/blog/Images/screenshot.png", html);
+        }
+
+        [Fact]
+        public async Task WhenPostHasGoodImage_ImageIsStillGood()
+        {
+            SeedPost("posts/3", "<img src=\"/blog/Images/screenshot.png\" />");
+
+            Assert.Contains("/blog/Images/screenshot.png", GetStoredBody("posts/3"));
+
+            var html = await RenderPost("posts/3");
+            
+            Assert.Contains("/blog/Images/screenshot.png", html);
+            Assert.DoesNotContain("/blog/Images//blog/", html);
+        }
+
+        private void SeedPost(string postId, string body)
+        {
+            var urlId = Post.GetIdForUrl(postId);
+            SetupData(session =>
+            {
+                session.Store(new BlogConfig { Id = "Blog/Config", Title = "Test Blog" });
+                session.Store(new User { Id = "users/1", FullName = "Test Author", Email = "author@test.com" });
+                session.Store(new PostComments
+                {
+                    Id = $"posts/comments/{urlId}",
+                    Post = new PostComments.PostReference { Id = postId, PublishAt = DateTimeOffset.Now.AddDays(-1) }
+                });
+                session.Store(new Post
+                {
+                    Id = postId,
+                    Title = "Test Post",
+                    Body = body,
+                    PublishAt = DateTimeOffset.Now.AddDays(-1),
+                    CreatedAt = DateTimeOffset.Now.AddDays(-1),
+                    AuthorId = "users/1",
+                    CommentsId = $"posts/comments/{urlId}",
+                    AllowComments = false,
+                    Tags = new List<string>()
+                });
+            });
+        }
+
+        private string GetStoredBody(string postId)
+        {
+            string body = null;
+            ExecuteWithScope(services =>
+            {
+                body = services.GetRequiredService<IDocumentSession>().Load<Post>(postId).Body;
+            });
+            return body;
+        }
+
+        private async Task<string> RenderPost(string postId)
+        {
+            var urlId = Post.GetIdForUrl(postId);
+            var response = await Factory
+                .CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = true })
+                .GetAsync($"/{urlId}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            return await response.Content.ReadAsStringAsync();
+        }
+    }
+}

--- a/RaccoonBlog.Web/Infrastructure/AutoMapper/Profiles/PostViewModelMapperProfile.cs
+++ b/RaccoonBlog.Web/Infrastructure/AutoMapper/Profiles/PostViewModelMapperProfile.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
 using RaccoonBlog.Web.Helpers;
 using RaccoonBlog.Web.Infrastructure.AutoMapper.Profiles.Resolvers;
@@ -19,6 +20,7 @@ namespace RaccoonBlog.Web.Infrastructure.AutoMapper.Profiles
 				.ForMember(x => x.IsCommentAllowed, o => o.MapFrom(m => m.AllowComments))
 				.ForMember(x => x.Title, o => o.MapFrom(m => WebUtility.HtmlDecode(m.Title)))
 				.ForMember(x => x.Author, o => o.Ignore())
+				.ForMember(x => x.Body, o => o.MapFrom(m => new HtmlString(ImageUrlRewriter.RewriteImageUrls(m.Body))))
 				;
 
 			CreateMap<PostComments.Comment, PostViewModel.Comment>()

--- a/RaccoonBlog.Web/Infrastructure/AutoMapper/Profiles/PostsViewModelMapperProfile.cs
+++ b/RaccoonBlog.Web/Infrastructure/AutoMapper/Profiles/PostsViewModelMapperProfile.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using Microsoft.AspNetCore.Html;
+using RaccoonBlog.Web.Infrastructure.AutoMapper.Profiles.Resolvers;
 using RaccoonBlog.Web.Infrastructure.Common;
 using RaccoonBlog.Web.Models;
 using RaccoonBlog.Web.ViewModels;
@@ -20,7 +21,7 @@ namespace RaccoonBlog.Web.Infrastructure.AutoMapper.Profiles
 				.ForMember(x => x.Author, o => o.Ignore())
 				.ForMember(x => x.PublishedAt, o => o.MapFrom(m => m.PublishAt))
 				.ForMember(x=>x.Title, o => o.MapFrom(m => System.Net.WebUtility.HtmlDecode(m.Title)))
-				.ForMember(x => x.Body, o => o.MapFrom(m => m.Body))
+				.ForMember(x => x.Body, o => o.MapFrom(m => new HtmlString(ImageUrlRewriter.RewriteImageUrls(m.Body))))
 				.ForMember(x => x.IsSerie, o => o.MapFrom(m => m.Title.Contains(":")))
 				;
 

--- a/RaccoonBlog.Web/Infrastructure/AutoMapper/Profiles/Resolvers/ImageUrlRewriter.cs
+++ b/RaccoonBlog.Web/Infrastructure/AutoMapper/Profiles/Resolvers/ImageUrlRewriter.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Text.RegularExpressions;
+using HtmlAgilityPack;
+
+namespace RaccoonBlog.Web.Infrastructure.AutoMapper.Profiles.Resolvers;
+
+public static class ImageUrlRewriter
+{
+    private static readonly Regex ImageUrlRegex = new(@"^https?://(?:www\.)?ayende\.com/blog/images/(.+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    public static string RewriteImageUrls(string html)
+    {
+        if (string.IsNullOrEmpty(html))
+            return html;
+
+        if (!html.Contains("<img", StringComparison.OrdinalIgnoreCase))
+            return html;
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var imgNodes = doc.DocumentNode.SelectNodes("//img[@src]");
+        if (imgNodes == null)
+            return html;
+
+        var changed = false;
+        foreach (var img in imgNodes)
+        {
+            var src = img.GetAttributeValue("src", "");
+            var newSrc = RewriteSrc(src);
+            if (newSrc == src)
+                continue;
+
+            img.SetAttributeValue("src", newSrc);
+            changed = true;
+        }
+
+        return changed ? doc.DocumentNode.OuterHtml : html;
+    }
+
+    private static string RewriteSrc(string src)
+    {
+        if (string.IsNullOrEmpty(src) || src.Contains(".."))
+            return src;
+
+        if (src.StartsWith("/blog/Images/", StringComparison.OrdinalIgnoreCase))
+            return src;
+        
+        var match = ImageUrlRegex.Match(src);
+        if (match.Success)
+            return "/blog/Images/" + match.Groups[1].Value;
+        
+        if (src.StartsWith("/Images/", StringComparison.OrdinalIgnoreCase))
+            return "/blog/Images/" + src.Substring("/Images/".Length);
+        
+        if (src.StartsWith("Images/", StringComparison.OrdinalIgnoreCase))
+            return "/blog/Images/" + src.Substring("Images/".Length);
+
+        return src;
+    }
+}


### PR DESCRIPTION
Post: https://staging.ayende.com/blog/364/confirmed-microsoft-is-cleaning-windows

In RavenDB:
`<img src="Images/ms-cleaning-windows.jpg" />`

At render time, AutoMapper calls ImageUrlRewriter.RewriteImageUrls(), which rewrites the src:
"Images/ms-cleaning-windows.jpg"  →  "/blog/Images/ms-cleaning-windows.jpg"

The browser loads /blog/Images/ms-cleaning-windows.jpg → ImagesController → RavenDB → image.

I decided to fix this at render time to avoid modifying old data.